### PR TITLE
Added missing header file for 'exit' command

### DIFF
--- a/src/linscan.cpp
+++ b/src/linscan.cpp
@@ -4,6 +4,7 @@
 #include <pthread.h>
 #include <time.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include "bitops.h"
 #include "types.h"


### PR DESCRIPTION
Got this error

```
mih/src/linscan.cpp:63:7: error: use of undeclared identifier 'exit'
                    exit(1);
```

from clang after calling `make`.
